### PR TITLE
Google Chrome devで3ページ目以降を読み込めない問題について

### DIFF
--- a/AutoPatchWork.safariextension/includes/AutoPatchWork.js
+++ b/AutoPatchWork.safariextension/includes/AutoPatchWork.js
@@ -674,7 +674,7 @@
         a.setAttribute('title', htmlDoc.querySelector('title').textContent.trim());
       }
       append_point.insertBefore(root, insert_point);
-      var docHeight = document.height;
+      var docHeight = document.body.clientHeight;
       var docs = get_next_elements(htmlDoc);
       var first = docs[0];
       if (!first) {
@@ -699,7 +699,7 @@
         docs[i] = insert_node;
       });
       if (status.bottom) status.bottom.style.height = Root.scrollHeight + 'px';
-      if (docHeight === document.height) {
+      if (docHeight === document.body.clientHeight) {
         return dispatch_event('AutoPatchWork.error', {message: 'missing next page contents'});
       }
       next = get_next(htmlDoc);


### PR DESCRIPTION
# 現象について

Google Chrome devにおいてAutoPatchWorkによるページの追加読み込みが2ページ目までしか読み込まれず、以降のページの読み込みが行われない。
デバッグモードで実行すると2ページ目を読み込んだ際に`missing next page contents`というメッセージがコンソールに表示される。
Google Chrome 30.0.1581.2 dev-mにおいて上記の現象を確認した。
# 原因

原因は2ページ目をXHRで取得して現在のページに追加した時に、追加分のページ内容が増えたことをチェックするために`document.height`を使用していること。
`document.height`はobsoleteとなっており(参考 https://developer.mozilla.org/ja/docs/Web/API/document.height )、このプロパティをサポートしていないブラウザもある。
Google Chrome devの上記バージョンも`document.height`をサポートしておらず、それによって追加分のページ内容が増えたかどうかのチェックが失敗し、3ページ目以降のページを読み込む必要がないと判断してしまっていた。
# 修正内容

`document.height`のかわりに`document.body.clientHeight`を用いた。
