### PR TITLE
format relative path of img element to absolute path

### DIFF
--- a/AutoPatchWork.safariextension/includes/AutoPatchWork.js
+++ b/AutoPatchWork.safariextension/includes/AutoPatchWork.js
@@ -684,7 +684,7 @@
       }
       docs.forEach(function (doc, i, docs) {
         Array.prototype.forEach.call(doc.querySelectorAll('img'), function(img) {
-          if (!img.getAttribute('src').test(/(^https?:\/\/|^data:|^\/)/)) {
+          if (!img.getAttribute('src').match(/(^https?:\/\/|^data:|^\/)/)) {
             img.setAttribute('src', next.getAttribute('href').replace(/\/[\w:%#\$&\?\(\)~\.=\+\-]*$/, '/') + img.getAttribute('src'));
           }
         });


### PR DESCRIPTION
https://github.com/os0x/AutoPatchWork/issues/7
画像ソースの相対パスを絶対パスに書き換える修正したものを使っていましたが、イシューになっていたのでプルリクしてみますm(__)m
