### PR TITLE
SITEINFO管理でのデータ取得をss-o.netからwedata.netに変えた

### DIFF
--- a/AutoPatchWork.safariextension/js/siteinfo_manager.js
+++ b/AutoPatchWork.safariextension/js/siteinfo_manager.js
@@ -415,7 +415,7 @@ var MICROFORMATs = [
   }
 
   function UpdateSiteinfo(callback) {
-    var url = 'http://ss-o.net/json/wedataAutoPagerize.json';
+    var url = 'http://wedata.net/databases/AutoPagerize/items.json';
     var xhr = new XMLHttpRequest();
     xhr.onload = function () {
       try {


### PR DESCRIPTION
SITEINFO管理が開かない

オプションで「SITEINFO管理」を開いても、リストに何も表示されない。

![image](https://user-images.githubusercontent.com/349500/27293787-5f7a1558-5552-11e7-9a56-93c0c6bacf36.png)

SITEINFO管理 sitemanager_info.js では、http://ss-o.net/json/wedataAutoPagerize.json を使っているが、このURLの内容が変

background.jsでは、
```
  var sso = 'http://os0x.heteml.jp/ss-onet/json/wedataAutoPagerizeSITEINFO.json';
  var wedata = 'http://wedata.net/databases/AutoPagerize/items.json';
```
なので、Wedata使うように変えます。